### PR TITLE
Added guidance for the CoC notice

### DIFF
--- a/0.9 Community Specification/3._Notices.md
+++ b/0.9 Community Specification/3._Notices.md
@@ -2,6 +2,8 @@
 
 Contact for Code of Conduct issues or inquires:  _________________
 
+[Ideally list two different individuals above (not a generic mailing list) as someone submitting a Code of Conduct complaint will want to know exactly who is receiving the complaint. We recommend two individuals in the case one of the individuals is the subject of or directly involved in the subject of a complaint.]
+
 
 ## Implementers
 


### PR DESCRIPTION
We have dealt with a number of issues that have led to listing two individuals directly. Added this guidance to the notice section.