### PR TITLE
Capture the authorized user's ID

### DIFF
--- a/0.9 Community Specification/3._Notices.md
+++ b/0.9 Community Specification/3._Notices.md
@@ -5,7 +5,7 @@ Contact for Code of Conduct issues or inquires:  _________________
 
 ## Implementers
 
-Per Community Specification License Section 2.1.3.3, implementers may indicate their acceptance of the Community Specification License by issuing a pull request to the Specification’s repository’s Notice.md file, including the implementer’s name, authorized individual, and specification version.
+Per Community Specification License Section 2.1.3.3, implementers may indicate their acceptance of the Community Specification License by issuing a pull request to the Specification’s repository’s Notice.md file, including the specification version, implementer’s name, authorized individuals' names and repository system identifier (e.g. GitHub ID).
 
 ---------------------------------------------------------------------------------
 

--- a/0.9 Community Specification/3._Notices.md
+++ b/0.9 Community Specification/3._Notices.md
@@ -5,13 +5,15 @@ Contact for Code of Conduct issues or inquires:  _________________
 
 ## Implementers
 
-Per Community Specification License Section 2.1.3.3, implementers may indicate their acceptance of the Community Specification License by issuing a pull request to the Specification’s repository’s Notice.md file, including the specification version, implementer’s name, authorized individuals' names and repository system identifier (e.g. GitHub ID).
+Per Community Specification License Section 2.1.3.3, implementers may indicate their acceptance of the Community Specification License by issuing a pull request to the Specification’s repository’s Notice.md file, including the implementer’s name, authorized individuals' names and repository system identifier (e.g. GitHub ID), and specification version.
+
+An Implementer may consent to accepting the current Community Specification License version or any future version of the Community Specification License by indicating "or later" after their specification version.
 
 ---------------------------------------------------------------------------------
 
 Implementer’s Name:
 
-Authorized Individual:
+Authorized Individual and System ID:
 
 Specification Version:
 


### PR DESCRIPTION
It may be hard to map GitHub IDs to real names without the ID also being documented.