### PR TITLE
Clarify the role of open source license and CSL

### DIFF
--- a/0.9 Community Specification/4._License.md
+++ b/0.9 Community Specification/4._License.md
@@ -7,4 +7,4 @@ Specifications in the repository are subject to the **Community Specification Li
 
 Source code should be included in a seperate repository/directory subject to a designated OSI approved open source license. The list of OSI approved licenses is available at https://opensource.org/licenses.  
 
-If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the MIT license. In the case of any conflict or confusion within this specification repository between the Community Specification License and the MIT or other designated open source license, the terms of the Community Specification License shall apply.
+If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the MIT license. In the case of any conflict or confusion within this specification repository between the Community Specification License and the MIT or other designated license, the terms of the Community Specification License shall apply.

--- a/0.9 Community Specification/4._License.md
+++ b/0.9 Community Specification/4._License.md
@@ -5,5 +5,6 @@ Specifications in the repository are subject to the **Community Specification Li
 
 ## Source Code License
 
-Source code should be included in a seperate repository/directory subject to a designated OSI approved open source license.  If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the MIT license.
+Source code should be included in a seperate repository/directory subject to a designated OSI approved open source license. The list of OSI approved licenses is available at https://opensource.org/licenses.  
 
+If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the MIT license. In the case of any conflict or confusion within this specification repository between the Community Specification License and the MIT or other designated open source license, the terms of the Community Specification License shall apply.


### PR DESCRIPTION
I'm not sure what was intended, but would it help to have a clarification that in the case of confusion or conflict between the MIT or other listed OSI license terms and the CSL, that the CSL applies? I'm thinking of a situation where someone includes code in the specification repo with a random OSI approved license identified (e.g. in the header) that causes confusion about what applies.