### PR TITLE
Update 1._Community_Specification_License_v0.9.md

### DIFF
--- a/0.9 Community Specification/1._Community_Specification_License_v0.9.md
+++ b/0.9 Community Specification/1._Community_Specification_License_v0.9.md
@@ -1,9 +1,10 @@
+# SPDX-License-Identifier: CC-BY-ND-4.0
 
 # Community Specification License 0.9
 
-**The Purpose of this License.**  This License sets forth the terms under which 1) Contributor will participate in and contribute to the development of specifications, standards, best practices, guidelines, and other similar materials under this Working Group, and 2) how the materials developed under this License may be used.  It is not intended for source code.  Capitalized terms are defined in the License’s last section.
+**The Purpose of this License.**  This License sets forth the terms under which 1) Contributor will participate in and contribute to the development of specifications, standards, best practices, guidelines, and other similar materials under this Working Group, and 2) how the materials developed under this License may be used.  It is not intended for source code.  Capitalized terms are defined in the License’s last section. The text of this Community Specification License 0.9 is Copyright 2020 the Joint Development Foundation and is licensed under the Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0) available here https://creativecommons.org/licenses/by-nd/4.0/.
 
-**1.	Copyright.**
+ **1.	Copyright.**
 
 **1.1.	Copyright License.**   Contributor grants everyone a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License)  copyright license, without any obligation for accounting, to reproduce, prepare derivative works of, publicly display, publicly perform, and distribute any materials it submits to the to the full extent of its copyright interest in those materials. Contributor also acknowledges that the Working Group may exercise copyright rights in the Specifications, including the rights to submit the Specification to another standards organization.
 


### PR DESCRIPTION
I think the license text itself should be licensed under a "ND" type license (though we can certainly discuss). In listing the license for the text, the question of who 'owns' the community spec license text needs to be answered and so to start of this discussion I've proposed JDF but am interested in the group's thoughts here. - Scott