### PR TITLE
Update ..Getting Started.md

### DIFF
--- a/0.9 Community Specification/..Getting Started.md
+++ b/0.9 Community Specification/..Getting Started.md
@@ -23,7 +23,7 @@ Create a new repository, and include the following files from the Community Spec
 
 # Best Practices.
 
-1. **CLA bot.** Enable a CLA Bot, such as EasyCLA or cla-bot, to require each Participant to agree to the **Community Specification Contributor License Agreement** prior to making any contribution.
+1. **CLA bot.** Enable a CLA Bot, such as EasyCLA or cla-bot, to require a **Community Specification Contributor License Agreement** signed (either by an individual contributor or by a contributor's employer, which CLA covers the employed contributor) and in place prior to making any contribution.
 
 1. **Use for specifications, not code.**  Use Community Specification Agreements for specfication development, not code.
 


### PR DESCRIPTION
In the CLA section, the term "Participant" was capitalized but undefined. It's also not defined in the spec itself (or I would reference that definition) and so I have reworded that section to read:  "1. **CLA bot.** Enable a CLA Bot, such as EasyCLA or cla-bot, to require a **Community Specification Contributor License Agreement** signed (either by an individual contributor or by a contributor's employer, which CLA covers the employed contributor) and in place prior to making any contribution."